### PR TITLE
Add Arbitrary instances for the main types

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,8 @@
   "authors": [
     "John A. De Goes <john@degoes.net> (http://degoes.net)",
     "Phil Freeman <paf31@cantab.net>",
-    "Gary Burgess <gary.burgess@gmail.com>"
+    "Gary Burgess <gary.burgess@gmail.com>",
+    "Jon Sterling <jon@jonmsterling.com>"
   ],
   "repository": {
     "type": "git",
@@ -23,7 +24,9 @@
   "dependencies": {
     "purescript-parsing": "^0.5.0",
     "purescript-validation": "^0.2.0",
-    "purescript-functions": "^0.1.0"
+    "purescript-functions": "^0.1.0",
+    "purescript-strongcheck": "^0.12.1",
+    "purescript-prelude": "^0.1.2"
   },
   "devDependencies": {
     "purescript-strongcheck": "^0.12.1"

--- a/docs/Text/Markdown/SlamDown.md
+++ b/docs/Text/Markdown/SlamDown.md
@@ -54,6 +54,7 @@ data Inline
 ##### Instances
 ``` purescript
 instance showInline :: Show Inline
+instance arbitraryInline :: Arbitrary Inline
 ```
 
 #### `ListType`
@@ -68,6 +69,7 @@ data ListType
 ``` purescript
 instance showListType :: Show ListType
 instance eqListType :: Eq ListType
+instance arbitraryListType :: Arbitrary ListType
 ```
 
 #### `CodeBlockType`
@@ -80,7 +82,8 @@ data CodeBlockType
 
 ##### Instances
 ``` purescript
-instance showCodeAttr :: Show CodeBlockType
+instance showCodeBlockType :: Show CodeBlockType
+instance arbitraryCodeBlockType :: Arbitrary CodeBlockType
 ```
 
 #### `LinkTarget`
@@ -94,6 +97,7 @@ data LinkTarget
 ##### Instances
 ``` purescript
 instance showLinkTarget :: Show LinkTarget
+instance arbitraryLinkTarget :: Arbitrary LinkTarget
 ```
 
 #### `Expr`
@@ -107,6 +111,7 @@ data Expr a
 ##### Instances
 ``` purescript
 instance showExpr :: (Show a) => Show (Expr a)
+instance arbitraryExpr :: (Arbitrary a) => Arbitrary (Expr a)
 ```
 
 #### `FormField`
@@ -122,6 +127,7 @@ data FormField
 ##### Instances
 ``` purescript
 instance showFormField :: Show FormField
+instance arbitraryFormField :: Arbitrary FormField
 ```
 
 #### `TextBoxType`
@@ -139,6 +145,7 @@ data TextBoxType
 ``` purescript
 instance showTextBoxType :: Show TextBoxType
 instance eqTextBoxType :: Eq TextBoxType
+instance arbitraryTextBoxType :: Arbitrary TextBoxType
 ```
 
 #### `everywhereM`

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -68,4 +68,9 @@ gulp.task('test', ['test-bundle'], function(cb) {
     run('node dist/test.js', { verbosity: 3 }).exec(cb);
 });
 
-gulp.task('default', sequence('make', 'docs'));
+gulp.task('dotpsci', function () {
+    return purescript.psci({ src: sources, ffi: foreigns })
+        .pipe(gulp.dest('.'));
+});
+
+gulp.task('default', sequence('make', 'docs', 'dotpsci'));

--- a/src/Text/Markdown/SlamDown.purs
+++ b/src/Text/Markdown/SlamDown.purs
@@ -1,4 +1,21 @@
-module Text.Markdown.SlamDown where
+module Text.Markdown.SlamDown
+  ( SlamDown(..)
+  , Block(..)
+  , Inline(..)
+  , ListType(..)
+  , CodeBlockType(..)
+  , LinkTarget(..)
+  , Expr(..)
+  , FormField(..)
+  , TextBoxType(..)
+  , everywhereM
+  , everywhere
+  , everywhereTopDownM
+  , everywhereTopDown
+  , everythingM
+  , everything
+  , eval
+  ) where
 
 import Prelude
 
@@ -8,10 +25,12 @@ import Data.Either (Either(..))
 import Data.Foldable (foldl, mconcat, elem)
 import Data.Function (on)
 import Data.Identity (runIdentity)
-import Data.List (List(..), concat, singleton)
+import Data.List (List(..), concat, singleton, toList)
 import Data.Maybe (Maybe(..), isJust)
 import Data.Monoid (Monoid, mempty)
 import Data.Traversable (Traversable, traverse)
+import Test.StrongCheck
+import Test.StrongCheck.Gen
 
 data SlamDown = SlamDown (List Block)
 
@@ -85,14 +104,45 @@ instance eqListType :: Eq ListType where
   eq (Ordered s1) (Ordered s2) = s1 == s2
   eq _            _            = false
 
+instance arbitraryListType :: Arbitrary ListType where
+  arbitrary = do
+    k <- chooseInt 0.0 1.0
+    case k of
+      0 -> Bullet <$> arbitrary
+      _ -> Ordered <$> arbitrary
+
+-- | Nota bene: this does not generate any recursive structure
+instance arbitraryInline :: Arbitrary Inline where
+  arbitrary = do
+    k <- chooseInt 0.0 10.0
+    case k of
+      0 -> Str <$> arbitrary
+      1 -> Entity <$> arbitrary
+      2 -> pure Space
+      3 -> pure SoftBreak
+      4 -> pure LineBreak
+      5 -> Code <$> arbitrary <*> arbitrary
+      6 -> FormField <$> arbitrary <*> arbitrary <*> arbitrary
+      7 -> pure (Emph Nil)
+      8 -> pure (Strong Nil)
+      9 -> Link Nil <$> arbitrary
+      _ -> Image Nil <$> arbitrary
 
 data CodeBlockType
   = Indented
   | Fenced Boolean String
 
-instance showCodeAttr :: Show CodeBlockType where
+instance showCodeBlockType :: Show CodeBlockType where
   show Indented      = "Indented"
   show (Fenced evaluated info) = "(Fenced " ++ show evaluated ++ " " ++ show info ++ ")"
+
+instance arbitraryCodeBlockType :: Arbitrary CodeBlockType where
+  arbitrary = do
+    k <- chooseInt 0.0 1.0
+    case k of
+      0 -> pure Indented
+      _ -> Fenced <$> arbitrary <*> arbitrary
+
 
 data LinkTarget
   = InlineLink String
@@ -102,6 +152,13 @@ instance showLinkTarget :: Show LinkTarget where
   show (InlineLink uri)    = "(InlineLink " ++ show uri ++ ")"
   show (ReferenceLink tgt) = "(ReferenceLink " ++ show tgt ++ ")"
 
+instance arbitraryLinkTarget :: Arbitrary LinkTarget where
+  arbitrary = do
+    k <- chooseInt 0.1 1.0
+    case k of
+      0 -> InlineLink <$> arbitrary
+      _ -> ReferenceLink <$> arbitrary
+
 data Expr a
   = Literal a
   | Unevaluated String
@@ -109,6 +166,16 @@ data Expr a
 instance showExpr :: (Show a) => Show (Expr a) where
   show (Literal a)   = "(Literal " ++ show a ++ ")"
   show (Unevaluated e) = "(Unevaluated " ++ show e ++ ")"
+
+genExpr :: forall a. Gen a -> Gen (Expr a)
+genExpr g = do
+  i <- chooseInt 0.0 1.0
+  case i of
+    0 -> Literal <$> g
+    _ -> Unevaluated <$> arbitrary
+
+instance arbitraryExpr :: (Arbitrary a) => Arbitrary (Expr a) where
+  arbitrary = genExpr arbitrary
 
 data FormField
   = TextBox        TextBoxType (Maybe (Expr String))
@@ -121,6 +188,18 @@ instance showFormField :: Show FormField where
   show (RadioButtons sel ls) = "(RadioButtons " ++ show sel ++ " " ++ show ls ++ ")"
   show (CheckBoxes bs ls) = "(CheckBoxes " ++ show bs ++ " " ++ show ls ++ ")"
   show (DropDown ls def) = "(DropDown " ++ show ls ++ " " ++ show def ++ ")"
+
+instance arbitraryFormField :: Arbitrary FormField where
+  arbitrary = do
+    k <- chooseInt 0.0 3.0
+    case k of
+      0 -> TextBox <$> arbitrary <*> arbitrary
+      1 -> RadioButtons <$> arbitrary <*> genExpr (listOf arbitrary)
+      2 -> CheckBoxes <$> genExpr (listOf arbitrary) <*> genExpr (listOf arbitrary)
+      _ -> DropDown <$> genExpr (listOf arbitrary) <*> arbitrary
+
+listOf :: forall f a. (Monad f) => GenT f a -> GenT f (List a)
+listOf = map toList <<< arrayOf
 
 data TextBoxType = PlainText | Numeric | Date | Time | DateTime
 
@@ -138,6 +217,15 @@ instance eqTextBoxType :: Eq TextBoxType where
   eq Time Time = true
   eq DateTime DateTime = true
   eq _ _ = false
+
+instance arbitraryTextBoxType :: Arbitrary TextBoxType where
+  arbitrary = elements PlainText $ toList
+    [ PlainText
+    , Numeric
+    , Date
+    , Time
+    , DateTime
+    ]
 
 everywhereM :: forall m. (Monad m) => (Block -> m Block) -> (Inline -> m Inline) -> SlamDown -> m SlamDown
 everywhereM b i (SlamDown bs) = SlamDown <$> traverse b' bs


### PR DESCRIPTION
- also added a task to the gulpfile to generate `.psci` files
- added explicit export list to `Text.Markdown.SlamDown`

This will let us specify and test certain properties (such as the fact that rendering and parsing commute).

resolves #39 