### PR TITLE
Update dependencies, fix checkbox eval behaviour

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,13 +22,9 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-parsing": "^0.7.0",
-    "purescript-validation": "^0.2.0",
     "purescript-functions": "^0.1.0",
+    "purescript-parsing": "^0.7.0",
     "purescript-strongcheck": "^0.13.0",
-    "purescript-prelude": "^0.1.2"
-  },
-  "devDependencies": {
-    "purescript-strongcheck": "^0.13.0"
+    "purescript-validation": "^0.2.0"
   }
 }

--- a/src/Text/Markdown/SlamDown.purs
+++ b/src/Text/Markdown/SlamDown.purs
@@ -322,9 +322,13 @@ eval fs = everywhereM b i
   f (RadioButtons sel opts) = RadioButtons <$> evalExpr fs.value sel <*> evalExpr fs.list opts
   f (CheckBoxes sels vals) = do
     vals' <- evalExpr fs.list vals
-    sels' <- evalExpr (\s -> fs.list s >>= pure <<< map (`elem` (getValues vals'))) sels
+    sels' <- evalExpr (mkBools vals') sels
     pure $ CheckBoxes sels' vals'
   f (DropDown opts default) = DropDown <$> evalExpr fs.list opts <*> traverse (evalExpr fs.value) default
+
+  mkBools vals' code = do
+    labels <- fs.list code
+    pure $ (`elem` labels) `map` getValues vals'
 
   evalExpr :: forall a. (String -> m a) -> Expr a -> m (Expr a)
   evalExpr _ (Literal a) = pure $ Literal a


### PR DESCRIPTION
Previously the checkbox label values list was truncated to the same length as the selected options list.