### PR TITLE
Dependency upgrades

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,13 +22,13 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-parsing": "^0.5.0",
+    "purescript-parsing": "^0.7.0",
     "purescript-validation": "^0.2.0",
     "purescript-functions": "^0.1.0",
-    "purescript-strongcheck": "^0.12.1",
+    "purescript-strongcheck": "^0.13.0",
     "purescript-prelude": "^0.1.2"
   },
   "devDependencies": {
-    "purescript-strongcheck": "^0.12.1"
+    "purescript-strongcheck": "^0.13.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "gulp": "^3.9.0",
     "gulp-purescript": "^0.6.0",
     "gulp-run": "^1.6.8",
-    "purescript": "^0.7.3-fixed",
+    "purescript": "^0.7.4",
     "run-sequence": "^1.1.1"
   }
 }


### PR DESCRIPTION
Upgrade `purescript-parsing`, `purescript-strongcheck`; upgrade `purescript` to `0.7.4`.

(These numerous little dependency upgrade patches I'm submitting are in the service of upgrading our little ecosystem to the new halogen in a mutually compatible way.)