### PR TITLE
Upgrade gulp-purescript to 0.7.0; update node version on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: false
 node_js:
-  - 0.10
+  - 0.12.7
 install:
   - npm install gulp bower -g
   - npm install

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "devDependencies": {
     "gulp": "^3.9.0",
-    "gulp-purescript": "^0.6.0",
+    "gulp-purescript": "^0.7.0",
     "gulp-run": "^1.6.8",
     "purescript": "^0.7.4",
     "run-sequence": "^1.1.1"


### PR DESCRIPTION
No need to do a release since this is just to improve the build. The new version of `gulp-purescript` seems to more reliably print warnings that previously had got swallowed up.