### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
 language: node_js
 sudo: false
 node_js:
-  - 0.12.7
+  - 4
 install:
   - npm install gulp bower -g
-  - npm install
-  - bower install --production
+  - npm install && bower install
 script:
-  - gulp
-  - bower install
   - gulp test

--- a/bower.json
+++ b/bower.json
@@ -22,13 +22,10 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-parsing": "^0.7.0",
-    "purescript-validation": "^0.2.0",
     "purescript-functions": "^0.1.0",
-    "purescript-strongcheck": "^0.13.0",
-    "purescript-prelude": "^0.1.2"
-  },
-  "devDependencies": {
-    "purescript-strongcheck": "^0.13.0"
+    "purescript-parsing": "^0.7.1",
+    "purescript-prelude": "^0.1.3",
+    "purescript-strongcheck": "^0.14.4",
+    "purescript-validation": "^0.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,10 @@
 {
-  "name": "purescript-markdown",
   "private": true,
   "devDependencies": {
     "gulp": "^3.9.0",
     "gulp-purescript": "^0.7.0",
     "gulp-run": "^1.6.8",
-    "purescript": "^0.7.4",
+    "purescript": "^0.7.5",
     "run-sequence": "^1.1.1"
   }
 }


### PR DESCRIPTION
We need to update everything to use strongcheck `^v0.14.4` as with the next compiler release everything depending on older versions will no longer compile: there was a bug in the compiler that meant a fatal error was ignored