### PR TITLE
Fix warnings; update build

### DIFF
--- a/docs/Text/Markdown/SlamDown.md
+++ b/docs/Text/Markdown/SlamDown.md
@@ -9,12 +9,12 @@ data SlamDown
 
 ##### Instances
 ``` purescript
-instance showSlamDown :: Show SlamDown
-instance eqSlamDown :: Eq SlamDown
-instance ordSlamDown :: Ord SlamDown
-instance semigroupSlamDown :: Semigroup SlamDown
-instance monoidSlamDown :: Monoid SlamDown
-instance arbitrarySlamDown :: Arbitrary SlamDown
+Show SlamDown
+Eq SlamDown
+Ord SlamDown
+Semigroup SlamDown
+Monoid SlamDown
+Arbitrary SlamDown
 ```
 
 #### `Block`
@@ -32,8 +32,8 @@ data Block
 
 ##### Instances
 ``` purescript
-instance showBlock :: Show Block
-instance arbitraryBlock :: Arbitrary Block
+Show Block
+Arbitrary Block
 ```
 
 #### `Inline`
@@ -55,8 +55,8 @@ data Inline
 
 ##### Instances
 ``` purescript
-instance showInline :: Show Inline
-instance arbitraryInline :: Arbitrary Inline
+Show Inline
+Arbitrary Inline
 ```
 
 #### `ListType`
@@ -69,9 +69,9 @@ data ListType
 
 ##### Instances
 ``` purescript
-instance showListType :: Show ListType
-instance eqListType :: Eq ListType
-instance arbitraryListType :: Arbitrary ListType
+Show ListType
+Eq ListType
+Arbitrary ListType
 ```
 
 #### `CodeBlockType`
@@ -84,8 +84,8 @@ data CodeBlockType
 
 ##### Instances
 ``` purescript
-instance showCodeBlockType :: Show CodeBlockType
-instance arbitraryCodeBlockType :: Arbitrary CodeBlockType
+Show CodeBlockType
+Arbitrary CodeBlockType
 ```
 
 #### `LinkTarget`
@@ -98,8 +98,8 @@ data LinkTarget
 
 ##### Instances
 ``` purescript
-instance showLinkTarget :: Show LinkTarget
-instance arbitraryLinkTarget :: Arbitrary LinkTarget
+Show LinkTarget
+Arbitrary LinkTarget
 ```
 
 #### `Expr`
@@ -112,8 +112,8 @@ data Expr a
 
 ##### Instances
 ``` purescript
-instance showExpr :: (Show a) => Show (Expr a)
-instance arbitraryExpr :: (Arbitrary a) => Arbitrary (Expr a)
+(Show a) => Show (Expr a)
+(Arbitrary a) => Arbitrary (Expr a)
 ```
 
 #### `FormField`
@@ -128,8 +128,8 @@ data FormField
 
 ##### Instances
 ``` purescript
-instance showFormField :: Show FormField
-instance arbitraryFormField :: Arbitrary FormField
+Show FormField
+Arbitrary FormField
 ```
 
 #### `TextBoxType`
@@ -145,9 +145,9 @@ data TextBoxType
 
 ##### Instances
 ``` purescript
-instance showTextBoxType :: Show TextBoxType
-instance eqTextBoxType :: Eq TextBoxType
-instance arbitraryTextBoxType :: Arbitrary TextBoxType
+Show TextBoxType
+Eq TextBoxType
+Arbitrary TextBoxType
 ```
 
 #### `everywhereM`

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "gulp": "^3.9.0",
     "gulp-purescript": "^0.7.0",
     "gulp-run": "^1.6.8",
-    "purescript": "^0.7.5",
+    "purescript": "^0.7.6",
     "run-sequence": "^1.1.1"
   }
 }

--- a/src/Text/Markdown/SlamDown.purs
+++ b/src/Text/Markdown/SlamDown.purs
@@ -21,12 +21,11 @@ import Prelude
 
 import Control.Bind ((<=<))
 
-import Data.Either (Either(..))
 import Data.Foldable (foldl, mconcat, elem)
 import Data.Function (on)
 import Data.Identity (runIdentity)
 import Data.List (List(..), concat, singleton, toList)
-import Data.Maybe (Maybe(..), isJust)
+import Data.Maybe (Maybe())
 import Data.Monoid (Monoid, mempty)
 import Data.Traversable (Traversable, traverse)
 import Test.StrongCheck

--- a/src/Text/Markdown/SlamDown/Parser.purs
+++ b/src/Text/Markdown/SlamDown/Parser.purs
@@ -17,7 +17,6 @@ import Data.Validation (V())
 import qualified Data.String as S
 
 import Text.Markdown.SlamDown
-import Text.Markdown.SlamDown.Parser.Utils
 import Text.Markdown.SlamDown.Parser.Inline
 import Text.Markdown.SlamDown.Parser.References
 

--- a/src/Text/Markdown/SlamDown/Parser/Utils.purs
+++ b/src/Text/Markdown/SlamDown/Parser/Utils.purs
@@ -18,8 +18,6 @@ import Text.Parsing.Parser (Parser())
 import Text.Parsing.Parser.Combinators (skipMany)
 import Text.Parsing.Parser.String (string, satisfy)
 
-import Text.Markdown.SlamDown
-
 isWhitespace :: Char -> Boolean
 isWhitespace = R.test wsRegex <<< fromChar
   where

--- a/src/Text/Markdown/SlamDown/Pretty.purs
+++ b/src/Text/Markdown/SlamDown/Pretty.purs
@@ -2,7 +2,6 @@ module Text.Markdown.SlamDown.Pretty (prettyPrintMd) where
 
 import Prelude
 
-import Data.Either (either)
 import Data.Foldable (fold)
 import Data.List (concatMap, zipWith, (..), toList, fromList, List(..), singleton)
 import Data.Maybe (fromMaybe, maybe)


### PR DESCRIPTION
This fixes a bunch of warnings caught by `psc` 0.7.6.

I think we can just do a patch version increment here, since no API is changed and the only dependency change is in `package.json` (which is only for dev dependencies).