### PR TITLE
Remove incorrect validation of RadioButton

### DIFF
--- a/src/Text/Markdown/SlamDown/Parser/Inline.purs
+++ b/src/Text/Markdown/SlamDown/Parser/Inline.purs
@@ -121,8 +121,6 @@ validateFormField field =
         (invalid <<< map ("Invalid text box: " ++))
         (pure <<< TextBox tbt <<< Just <<< Literal)
         (validateTextOfType tbt def)
-    RadioButtons (Literal sel) (Literal ls) | not (sel `elem` ls) ->
-      invalid ["Invalid radio buttons"]
     CheckBoxes (Literal bs) (Literal ls) | length bs /= length ls ->
       invalid ["Invalid checkboxes"]
     DropDown (Literal ls) (Just (Literal def)) | not (def `elem` ls) ->


### PR DESCRIPTION
It appears that the *expected* representation for `RadioButton` is to have the selected item be separate from the list of items. Either this validation needed to change, or we should change the representation.

This is the cause of [SD-1048](https://slamdata.atlassian.net/browse/SD-1048).