### PR TITLE
[SD-1370] Don't require dropdown default to occur in list of elements

### DIFF
--- a/src/Text/Markdown/SlamDown.purs
+++ b/src/Text/Markdown/SlamDown.purs
@@ -294,15 +294,17 @@ everythingM b i (SlamDown bs) = mconcat <$> traverse b' bs
 everything :: forall r. (Monoid r) => (Block -> r) -> (Inline -> r) -> SlamDown -> r
 everything b i = runIdentity <<< everythingM (pure <<< b) (pure <<< i)
 
-eval :: forall m. (Monad m)
-      => { code :: String -> m String
-         , block :: String -> List String -> m String
-         , text :: TextBoxType -> String -> m String
-         , value :: String -> m String
-         , list :: String -> m (List String)
-         }
-      -> SlamDown
-      -> m SlamDown
+eval
+  :: forall m
+   . (Monad m)
+  => { code :: String -> m String
+     , block :: String -> List String -> m String
+     , text :: TextBoxType -> String -> m String
+     , value :: String -> m String
+     , list :: String -> m (List String)
+     }
+  -> SlamDown
+  -> m SlamDown
 eval fs = everywhereM b i
   where
 

--- a/src/Text/Markdown/SlamDown/Parser/Inline.purs
+++ b/src/Text/Markdown/SlamDown/Parser/Inline.purs
@@ -123,8 +123,6 @@ validateFormField field =
         (validateTextOfType tbt def)
     CheckBoxes (Literal bs) (Literal ls) | length bs /= length ls ->
       invalid ["Invalid checkboxes"]
-    DropDown (Literal ls) (Just (Literal def)) | not (def `elem` ls) ->
-      invalid ["Invalid dropdown"]
     _ -> pure field
 
 validateInline :: Inline -> V (Array String) Inline

--- a/test/src/Test/Main.purs
+++ b/test/src/Test/Main.purs
@@ -39,14 +39,12 @@ testValidations = do
   let document =
         "welp = __:__ (not-a-time)\n\
         \welp = #__ (not-a-number)\n\
-        \welp = __-__-__ __:__ (hi)\n\
-        \city = {BOS, SFO, NYC} (NOPE)"
+        \welp = __-__-__ __:__ (hi)"
 
   let expectedErrors =
         [ "Invalid text box: Expected Time"
         , "Invalid text box: Expected Numeric"
         , "Invalid text box: Expected DateTime"
-        , "Invalid dropdown"
         ]
 
   assert $ validate document == Left expectedErrors


### PR DESCRIPTION
To resolve [SD-1370](https://slamdata.atlassian.net/browse/SD-1370); for more context, see the discussion toward the bottom of [SD-1360](https://slamdata.atlassian.net/browse/SD-1360).

We will [adjust `purescript-markdown-halogen`](https://slamdata.atlassian.net/browse/SD-1371) to treat dropdowns in the same way as radio buttons (adding the default to the list if it is not already present). We will also remove the "dummy" empty value that is currently being added.