### PR TITLE
SD-1651: spaces in (dropdown, checkbox, radio button)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "devDependencies": {
-    "purescript": "^0.8.2"
+    "purescript": "^0.8.5"
   }
 }

--- a/src/Text/Markdown/SlamDown/Parser/Inline.purs
+++ b/src/Text/Markdown/SlamDown/Parser/Inline.purs
@@ -346,7 +346,7 @@ inlines = L.many inline2 <* PS.eof
 
     dropDown ∷ P.Parser String (SD.FormField a)
     dropDown = do
-      let item = SD.stringValue <$> manyOf \c → not $ c `elem` ['{','}',',',' ','!','`','(',')']
+      let item = SD.stringValue <$> manyOf \c → not $ c `elem` ['{','}',',','!','`','(',')']
       ls ← PU.braces $ expr id $ (PC.try (PU.skipSpaces *> item)) `PC.sepBy` (PU.skipSpaces *> PS.string ",")
       sel ← PC.optionMaybe $ PU.skipSpaces *> (PU.parens $ expr id $ item)
       return $ SD.DropDown sel ls

--- a/src/Text/Markdown/SlamDown/Parser/Inline.purs
+++ b/src/Text/Markdown/SlamDown/Parser/Inline.purs
@@ -307,7 +307,7 @@ inlines = L.many inline2 <* PS.eof
         go i (L.Cons x xs) = L.Cons (Tuple i x) $ go (i + 1) xs
 
     radioButtons ∷ P.Parser String (SD.FormField a)
-    radioButtons = literalRadioButtons <|> evaluatedRadioButtons
+    radioButtons = PC.try evaluatedRadioButtons <|> literalRadioButtons
       where
         literalRadioButtons = do
           ls ← L.some $ PC.try do
@@ -329,7 +329,7 @@ inlines = L.many inline2 <* PS.eof
             <*> (PU.skipSpaces *> unevaluated)
 
     checkBoxes ∷ P.Parser String (SD.FormField a)
-    checkBoxes = literalCheckBoxes <|> evaluatedCheckBoxes
+    checkBoxes = PC.try evaluatedCheckBoxes <|> literalCheckBoxes
       where
         literalCheckBoxes = do
           ls ← L.some $ PC.try do
@@ -347,7 +347,7 @@ inlines = L.many inline2 <* PS.eof
             <*> (PU.skipSpaces *> unevaluated)
 
     dropDown ∷ P.Parser String (SD.FormField a)
-    dropDown = literalDropDown <|> evaluatedDropDown
+    dropDown = PC.try evaluatedDropDown <|> literalDropDown
       where
         literalDropDown = do
           let item = SD.stringValue <<< S.trim <$> manyOf \c → not $ c `elem` ['{','}',',','!','`','(',')']

--- a/src/Text/Markdown/SlamDown/Parser/Inline.purs
+++ b/src/Text/Markdown/SlamDown/Parser/Inline.purs
@@ -177,7 +177,7 @@ inlines = L.many inline2 <* PS.eof
     f is = SD.Strong $ L.singleton $ SD.Emph is
 
   space ∷ P.Parser String (SD.Inline a)
-  space = (toSpace <<< (S.fromChar <$>)) <$> L.some (PS.satisfy PU.isWhitespace)
+  space = (toSpace <<< (S.fromChar <$> _)) <$> L.some (PS.satisfy PU.isWhitespace)
     where
     toSpace cs
       | "\n" `elem` cs =
@@ -456,4 +456,3 @@ unevaluated = do
   PS.string "!"
   ticks ← someOf (\x → S.fromChar x == "`")
   SD.Unevaluated <<< S.fromCharArray <<< L.fromList <$> PC.manyTill PS.anyChar (PS.string ticks)
-

--- a/src/Text/Markdown/SlamDown/Syntax/FormField.purs
+++ b/src/Text/Markdown/SlamDown/Syntax/FormField.purs
@@ -158,7 +158,7 @@ instance arbitraryFormField ∷ (SC.Arbitrary a, Eq a) ⇒ SC.Arbitrary (FormFie
               Literal <$> Gen.chooseInt 0.0 (Int.toNumber $ n - 1)
             pure $ DropDown mi xse
           Unevaluated e → do
-            mx ← genMaybe $ Unevaluated <$> genUnevaluated
+            mx ← pure <<< Unevaluated <$> genUnevaluated
             pure $ DropDown mx xse
 
 instance arbitraryFormFieldIdentity ∷ (SC.Arbitrary a, Eq a) ⇒ SC.Arbitrary (FormFieldP Identity a) where

--- a/test/src/Test/Main.purs
+++ b/test/src/Test/Main.purs
@@ -231,6 +231,8 @@ static = do
   testDocument $ SDP.parseMd "[numeric field] = #______ (23)"
   testDocument $ SDP.parseMd "i9a0qvg8* = ______ (9a0qvg8h)"
   testDocument $ SDP.parseMd "xeiodbdy  = [x] "
+  testDocument $ SDP.parseMd "4udo5r  = {!`  `} (!`èŒ`)"
+  testDocument $ SDP.parseMd "4udo5r  = {!`   `} (!` `)"
 
   C.log "All static tests passed!"
 


### PR DESCRIPTION
To address https://slamdata.atlassian.net/browse/SD-1648 / https://slamdata.atlassian.net/browse/SD-1651.

This ended up necessitating not only changes to the parser, but also changes to the data model. I think these changes are desirable though, since they make the treatment of dropdowns & radio buttons closer to that of checkboxes. There is also now no longer any notion of adding a "missing" selected item to the list, since we store indices canonically.