### PR TITLE
Improve checkbox model

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,6 +30,7 @@
     "purescript-parsing": "^0.8.0",
     "purescript-prelude": "^0.1.3",
     "purescript-strongcheck": "^0.14.4",
-    "purescript-validation": "^0.2.1"
+    "purescript-validation": "^0.2.1",
+    "purescript-sets": "^0.5.7"
   }
 }

--- a/src/Text/Markdown/SlamDown/Parser/Inline.purs
+++ b/src/Text/Markdown/SlamDown/Parser/Inline.purs
@@ -333,7 +333,7 @@ inlines = L.many inline2 <* PS.eof
             PU.skipSpaces
             l ← item
             return $ Tuple b l
-          return $ SD.CheckBoxes (SD.Literal (map fst ls)) (SD.Literal (map snd ls))
+          return $ SD.CheckBoxes (SD.Literal $ snd <$> L.filter fst ls) (SD.Literal $ snd <$> ls)
 
         evaluatedCheckBoxes =
           SD.CheckBoxes

--- a/src/Text/Markdown/SlamDown/Parser/Inline.purs
+++ b/src/Text/Markdown/SlamDown/Parser/Inline.purs
@@ -98,8 +98,6 @@ validateFormField
   → V.V (Array String) (SD.FormField a)
 validateFormField field =
   case field of
-    SD.CheckBoxes (SD.Literal bs) (SD.Literal ls) | L.length bs /= L.length ls →
-      V.invalid ["Invalid checkboxes"]
     SD.CheckBoxes (SD.Literal _) (SD.Unevaluated _) →
       V.invalid ["Checkbox values & selection must be both literals or both unevaluated expressions"]
     SD.CheckBoxes (SD.Unevaluated _) (SD.Literal _) →

--- a/src/Text/Markdown/SlamDown/Pretty.purs
+++ b/src/Text/Markdown/SlamDown/Pretty.purs
@@ -6,7 +6,7 @@ module Text.Markdown.SlamDown.Pretty
 import Prelude
 
 import Data.Array as A
-import Data.Foldable (fold)
+import Data.Foldable (fold, elem)
 import Data.Identity (Identity(..))
 import Data.Functor.Compose (Compose(), decompose)
 import Data.HugeNum as HN
@@ -183,11 +183,11 @@ prettyPrintFormElement el =
         S.joinWith " " $ L.fromList (map radioButton ls)
     SD.RadioButtons (SD.Unevaluated bs) (SD.Unevaluated ls) →
       "(!`" <> bs <> "`) !`" <> ls <> "`"
-    SD.CheckBoxes (SD.Literal bs) (SD.Literal ls) →
+    SD.CheckBoxes (SD.Literal sel) (SD.Literal ls) →
       let
-        checkBox b l = (if b then "[x] " else "[] ") <> SD.renderValue l
+        checkBox l = (if elem l sel then "[x] " else "[] ") <> SD.renderValue l
       in
-        S.joinWith " " $ L.fromList (L.zipWith checkBox bs ls)
+        S.joinWith " " <<< L.fromList $ checkBox <$> ls
     SD.CheckBoxes (SD.Unevaluated bs) (SD.Unevaluated ls) →
       "[!`" <> bs <> "`] !`" <> ls <> "`"
     SD.DropDown sel lbls →

--- a/src/Text/Markdown/SlamDown/Syntax.purs
+++ b/src/Text/Markdown/SlamDown/Syntax.purs
@@ -9,7 +9,6 @@ module Text.Markdown.SlamDown.Syntax
 
 import Prelude
 
-import Data.Function (on)
 import Data.List as L
 import Data.Monoid (class Monoid, mempty)
 import Test.StrongCheck as SC
@@ -30,12 +29,8 @@ instance functorSlamDownP ∷ Functor SlamDownP where
 instance showSlamDownP ∷ (Show a) ⇒ Show (SlamDownP a) where
   show (SlamDown bs) = "(SlamDown " ++ show bs ++ ")"
 
-instance eqSlamDownP ∷ (Eq a, Ord a) ⇒ Eq (SlamDownP a) where
-  eq (SlamDown bs1) (SlamDown bs2) = bs1 == bs2
-
--- TODO: replace this with a proper `Ord` instance.
-instance ordSlamDownP ∷ (Show a, Eq a, Ord a) ⇒ Ord (SlamDownP a) where
-  compare = compare `on` show
+derive instance eqSlamDownP ∷ (Eq a, Ord a) ⇒ Eq (SlamDownP a)
+derive instance ordSlamDownP ∷ (Eq a, Ord a) ⇒ Ord (SlamDownP a)
 
 instance semigroupSlamDownP ∷ Semigroup (SlamDownP a) where
   append (SlamDown bs1) (SlamDown bs2) = SlamDown (bs1 <> bs2)

--- a/src/Text/Markdown/SlamDown/Syntax.purs
+++ b/src/Text/Markdown/SlamDown/Syntax.purs
@@ -30,11 +30,11 @@ instance functorSlamDownP ∷ Functor SlamDownP where
 instance showSlamDownP ∷ (Show a) ⇒ Show (SlamDownP a) where
   show (SlamDown bs) = "(SlamDown " ++ show bs ++ ")"
 
-instance eqSlamDownP ∷ (Eq a) ⇒ Eq (SlamDownP a) where
+instance eqSlamDownP ∷ (Eq a, Ord a) ⇒ Eq (SlamDownP a) where
   eq (SlamDown bs1) (SlamDown bs2) = bs1 == bs2
 
 -- TODO: replace this with a proper `Ord` instance.
-instance ordSlamDownP ∷ (Show a, Eq a) ⇒ Ord (SlamDownP a) where
+instance ordSlamDownP ∷ (Show a, Eq a, Ord a) ⇒ Ord (SlamDownP a) where
   compare = compare `on` show
 
 instance semigroupSlamDownP ∷ Semigroup (SlamDownP a) where
@@ -45,4 +45,3 @@ instance monoidSlamDownP ∷ Monoid (SlamDownP a) where
 
 instance arbitrarySlamDownP ∷ (SC.Arbitrary a, Eq a) ⇒ SC.Arbitrary (SlamDownP a) where
   arbitrary = SlamDown <<< L.toList <$> Gen.arrayOf SC.arbitrary
-

--- a/src/Text/Markdown/SlamDown/Syntax/Block.purs
+++ b/src/Text/Markdown/SlamDown/Syntax/Block.purs
@@ -40,7 +40,7 @@ instance showBlock ∷ (Show a) ⇒ Show (Block a) where
   show (LinkReference l uri) = "(LinkReference " ++ show l ++ " " ++ show uri ++ ")"
   show Rule = "Rule"
 
-instance eqBlock ∷ (Eq a) ⇒ Eq (Block a) where
+instance eqBlock ∷ (Eq a, Ord a) ⇒ Eq (Block a) where
   eq (Paragraph is1) (Paragraph is2) = is1 == is2
   eq (Header n1 is1) (Header n2 is2) = n1 == n2 && is1 == is2
   eq (Blockquote bs1) (Blockquote bs2) = bs1 == bs2
@@ -101,4 +101,3 @@ instance arbitraryCodeBlockType ∷ SC.Arbitrary CodeBlockType where
   arbitrary = do
     b ← SC.arbitrary
     if b then pure Indented else Fenced <$> SC.arbitrary <*> SC.arbitrary
-

--- a/src/Text/Markdown/SlamDown/Syntax/Block.purs
+++ b/src/Text/Markdown/SlamDown/Syntax/Block.purs
@@ -40,8 +40,8 @@ instance showBlock ∷ (Show a) ⇒ Show (Block a) where
   show (LinkReference l uri) = "(LinkReference " ++ show l ++ " " ++ show uri ++ ")"
   show Rule = "Rule"
 
-derive instance eqBlock ∷ (Eq a, Ord a) => Eq (Block a)
-derive instance ordBlock ∷ (Ord a) => Ord (Block a)
+derive instance eqBlock ∷ (Eq a, Ord a) ⇒ Eq (Block a)
+derive instance ordBlock ∷ (Ord a) ⇒ Ord (Block a)
 
 -- | Nota bene: this does not generate any recursive structure
 instance arbitraryBlock ∷ (SC.Arbitrary a, Eq a) ⇒ SC.Arbitrary (Block a) where

--- a/src/Text/Markdown/SlamDown/Syntax/Block.purs
+++ b/src/Text/Markdown/SlamDown/Syntax/Block.purs
@@ -40,15 +40,8 @@ instance showBlock ∷ (Show a) ⇒ Show (Block a) where
   show (LinkReference l uri) = "(LinkReference " ++ show l ++ " " ++ show uri ++ ")"
   show Rule = "Rule"
 
-instance eqBlock ∷ (Eq a, Ord a) ⇒ Eq (Block a) where
-  eq (Paragraph is1) (Paragraph is2) = is1 == is2
-  eq (Header n1 is1) (Header n2 is2) = n1 == n2 && is1 == is2
-  eq (Blockquote bs1) (Blockquote bs2) = bs1 == bs2
-  eq (Lst ty1 bss1) (Lst ty2 bss2) = ty1 == ty2 && bss1 == bss2
-  eq (CodeBlock ty1 ss1) (CodeBlock ty2 ss2) = ty1 == ty2 && ss1 == ss2
-  eq (LinkReference l1 uri1) (LinkReference l2 uri2) = l1 == l2 && uri1 == uri2
-  eq Rule Rule = true
-  eq _ _ = false
+derive instance eqBlock ∷ (Eq a, Ord a) => Eq (Block a)
+derive instance ordBlock ∷ (Ord a) => Ord (Block a)
 
 -- | Nota bene: this does not generate any recursive structure
 instance arbitraryBlock ∷ (SC.Arbitrary a, Eq a) ⇒ SC.Arbitrary (Block a) where
@@ -74,10 +67,8 @@ instance showListType ∷ Show ListType where
   show (Bullet s) = "(Bullet " ++ show s ++ ")"
   show (Ordered s) = "(Ordered " ++ show s ++ ")"
 
-instance eqListType ∷ Eq ListType where
-  eq (Bullet s1)  (Bullet s2) = s1 == s2
-  eq (Ordered s1) (Ordered s2) = s1 == s2
-  eq _ _ = false
+derive instance eqListType ∷ Eq ListType
+derive instance ordListType ∷ Ord ListType
 
 instance arbitraryListType ∷ SC.Arbitrary ListType where
   arbitrary = do
@@ -92,10 +83,8 @@ instance showCodeBlockType ∷ Show CodeBlockType where
   show Indented = "Indented"
   show (Fenced evaluated info) = "(Fenced " ++ show evaluated ++ " " ++ show info ++ ")"
 
-instance eqCodeBlockType ∷ Eq CodeBlockType where
-  eq Indented Indented = true
-  eq (Fenced b1 s1) (Fenced b2 s2) = b1 == b2 && s1 == s2
-  eq _ _ = false
+derive instance eqCodeBlockType ∷ Eq CodeBlockType
+derive instance ordCodeBlockType ∷ Ord CodeBlockType
 
 instance arbitraryCodeBlockType ∷ SC.Arbitrary CodeBlockType where
   arbitrary = do

--- a/src/Text/Markdown/SlamDown/Syntax/FormField.purs
+++ b/src/Text/Markdown/SlamDown/Syntax/FormField.purs
@@ -293,8 +293,8 @@ instance showExpr ∷ (Show a) ⇒ Show (Expr a) where
       Literal a → "(Literal " ++ show a ++ ")"
       Unevaluated e → "(Unevaluated " ++ show e ++ ")"
 
-derive instance eqExpr ∷ Eq a => Eq (Expr a)
-derive instance ordExpr ∷ Ord a => Ord (Expr a)
+derive instance eqExpr ∷ Eq a ⇒ Eq (Expr a)
+derive instance ordExpr ∷ Ord a ⇒ Ord (Expr a)
 
 genExpr ∷ ∀ a. Gen.Gen a → Gen.Gen (Expr a)
 genExpr g = do

--- a/src/Text/Markdown/SlamDown/Syntax/FormField.purs
+++ b/src/Text/Markdown/SlamDown/Syntax/FormField.purs
@@ -55,7 +55,7 @@ traverseFormField eta field =
   case field of
     TextBox tb → TextBox <$> TB.traverseTextBox (decompose >>> TR.traverse eta >>> map Compose) tb
     RadioButtons sel ls → RadioButtons <$> eta sel <*> eta ls
-    CheckBoxes sel ls → CheckBoxes <$> eta ls <*> eta ls
+    CheckBoxes sel ls → CheckBoxes <$> eta sel <*> eta ls
     DropDown sel ls → DropDown <$> TR.traverse eta sel <*> eta ls
 
 instance functorFormField ∷ (Functor f) ⇒ Functor (FormFieldP f) where

--- a/src/Text/Markdown/SlamDown/Syntax/Inline.purs
+++ b/src/Text/Markdown/SlamDown/Syntax/Inline.purs
@@ -26,8 +26,8 @@ data Inline a
   | FormField String Boolean (FormField a)
 
 instance functorInline ∷ Functor Inline where
-  map f x =
-    case x of
+  map f =
+    case _ of
       Str s → Str s
       Entity s → Entity s
       Space → Space
@@ -53,19 +53,8 @@ instance showInline ∷ (Show a) ⇒ Show (Inline a) where
   show (Image is uri) = "(Image " ++ show is ++ " " ++ show uri ++ ")"
   show (FormField l r f) = "(FormField " ++ show l ++ " " ++ show r ++ " " ++ show f ++ ")"
 
-instance eqInline ∷ (Eq a, Ord a) ⇒ Eq (Inline a) where
-  eq (Str s1) (Str s2) = s1 == s2
-  eq (Entity s1) (Entity s2) = s1 == s2
-  eq Space Space = true
-  eq SoftBreak SoftBreak = true
-  eq LineBreak LineBreak = true
-  eq (Emph is1) (Emph is2) = is1 == is2
-  eq (Strong is1) (Strong is2) = is1 == is2
-  eq (Code b1 s1) (Code b2 s2) = b1 == b2 && s1 == s2
-  eq (Link is1 tgt1) (Link is2 tgt2) = is1 == is2 && tgt1 == tgt2
-  eq (Image is1 s1) (Image is2 s2) = is1 == is2 && s1 == s2
-  eq (FormField s1 b1 f1) (FormField s2 b2 f2) = s1 == s2 && b1 == b2 && f1 == f2
-  eq _ _ = false
+derive instance eqInline ∷ (Eq a, Ord a) => Eq (Inline a)
+derive instance ordInline ∷ (Ord a) => Ord (Inline a)
 
 -- | Nota bene: this does not generate any recursive structure
 instance arbitraryInline ∷ (SC.Arbitrary a, Eq a) ⇒ SC.Arbitrary (Inline a) where
@@ -89,14 +78,12 @@ data LinkTarget
   = InlineLink String
   | ReferenceLink (M.Maybe String)
 
+derive instance eqLinkTarget ∷ Eq LinkTarget
+derive instance ordLinkTarget ∷ Ord LinkTarget
+
 instance showLinkTarget ∷ Show LinkTarget where
   show (InlineLink uri) = "(InlineLink " ++ show uri ++ ")"
   show (ReferenceLink tgt) = "(ReferenceLink " ++ show tgt ++ ")"
-
-instance eqLinkTarget ∷ Eq LinkTarget where
-  eq (InlineLink uri1) (InlineLink uri2) = uri1 == uri2
-  eq (ReferenceLink tgt1) (ReferenceLink tgt2) = tgt1 == tgt2
-  eq _ _ = false
 
 instance arbitraryLinkTarget ∷ SC.Arbitrary LinkTarget where
   arbitrary = do

--- a/src/Text/Markdown/SlamDown/Syntax/Inline.purs
+++ b/src/Text/Markdown/SlamDown/Syntax/Inline.purs
@@ -53,7 +53,7 @@ instance showInline ∷ (Show a) ⇒ Show (Inline a) where
   show (Image is uri) = "(Image " ++ show is ++ " " ++ show uri ++ ")"
   show (FormField l r f) = "(FormField " ++ show l ++ " " ++ show r ++ " " ++ show f ++ ")"
 
-instance eqInline ∷ (Eq a) ⇒ Eq (Inline a) where
+instance eqInline ∷ (Eq a, Ord a) ⇒ Eq (Inline a) where
   eq (Str s1) (Str s2) = s1 == s2
   eq (Entity s1) (Entity s2) = s1 == s2
   eq Space Space = true
@@ -102,4 +102,3 @@ instance arbitraryLinkTarget ∷ SC.Arbitrary LinkTarget where
   arbitrary = do
     b ← SC.arbitrary
     if b then InlineLink <$> SC.arbitrary else ReferenceLink <$> SC.arbitrary
-

--- a/src/Text/Markdown/SlamDown/Syntax/Inline.purs
+++ b/src/Text/Markdown/SlamDown/Syntax/Inline.purs
@@ -53,8 +53,8 @@ instance showInline ∷ (Show a) ⇒ Show (Inline a) where
   show (Image is uri) = "(Image " ++ show is ++ " " ++ show uri ++ ")"
   show (FormField l r f) = "(FormField " ++ show l ++ " " ++ show r ++ " " ++ show f ++ ")"
 
-derive instance eqInline ∷ (Eq a, Ord a) => Eq (Inline a)
-derive instance ordInline ∷ (Ord a) => Ord (Inline a)
+derive instance eqInline ∷ (Eq a, Ord a) ⇒ Eq (Inline a)
+derive instance ordInline ∷ (Ord a) ⇒ Ord (Inline a)
 
 -- | Nota bene: this does not generate any recursive structure
 instance arbitraryInline ∷ (SC.Arbitrary a, Eq a) ⇒ SC.Arbitrary (Inline a) where

--- a/src/Text/Markdown/SlamDown/Syntax/Value.purs
+++ b/src/Text/Markdown/SlamDown/Syntax/Value.purs
@@ -6,7 +6,7 @@ module Text.Markdown.SlamDown.Syntax.Value
 
 import Prelude
 
-class (Eq a) ⇐ Value a where
+class (Eq a, Ord a) ⇐ Value a where
   stringValue
     ∷ String
     → a

--- a/test/src/Test/Main.purs
+++ b/test/src/Test/Main.purs
@@ -39,7 +39,7 @@ derive instance eqNonEmptyString ∷ Eq NonEmptyString
 derive instance ordNonEmptyString ∷ Ord NonEmptyString
 
 genChar ∷ Gen.Gen Char
-genChar = Gen.elements '-' $ L.toList $ S.toCharArray "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 "
+genChar = Gen.elements '-' $ L.toList $ S.toCharArray "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 @!#$%^"
 
 instance arbitraryNonEmptyString ∷ SC.Arbitrary NonEmptyString where
   arbitrary =

--- a/test/src/Test/Main.purs
+++ b/test/src/Test/Main.purs
@@ -36,9 +36,10 @@ type TestEffects e =
 
 newtype NonEmptyString = NonEmptyString String
 derive instance eqNonEmptyString ∷ Eq NonEmptyString
+derive instance ordNonEmptyString ∷ Ord NonEmptyString
 
 genChar ∷ Gen.Gen Char
-genChar = Gen.elements '-' $ L.toList $ S.toCharArray "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@#$%^&*"
+genChar = Gen.elements '-' $ L.toList $ S.toCharArray "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 "
 
 instance arbitraryNonEmptyString ∷ SC.Arbitrary NonEmptyString where
   arbitrary =


### PR DESCRIPTION
- Update the checkbox model to cohere with the rest of the setup, as discussed yesterday. Instead of having a list of booleans as the selection, we carry a list of values (identified up to permutation). This fixes the bizarre semantics of evaluation, where a client had to "essentially" return a list of values (not booleans) from the evaluator for `Expr (List Boolean)`.

- Checkboxes now have the same merging semantics as the rest of the form fields.

- Added a bunch of `Ord` instances.