### PR TITLE
Use isAlphaNum from purescript-unicode

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -32,6 +32,7 @@
     "purescript-sets": "^3.0.0",
     "purescript-strings": "^3.0.0",
     "purescript-strongcheck": "^3.0.0",
+    "purescript-unicode": "^3.0.1",
     "purescript-validation": "^3.0.0",
     "purescript-datetime": "^3.0.0"
   }

--- a/src/Text/Markdown/SlamDown/Parser/Inline.purs
+++ b/src/Text/Markdown/SlamDown/Parser/Inline.purs
@@ -12,6 +12,7 @@ import Control.Lazy as Lazy
 
 import Data.Array as A
 import Data.Bifunctor (lmap)
+import Data.Char.Unicode (isAlphaNum)
 import Data.Const (Const(..))
 import Data.DateTime as DT
 import Data.Either (Either(..))
@@ -158,13 +159,6 @@ inlines = L.many inline2 <* PS.eof
 
   alphaNumStr ∷ P.Parser String (SD.Inline a)
   alphaNumStr = SD.Str <$> someOf isAlphaNum
-
-  isAlphaNum ∷ Char → Boolean
-  isAlphaNum c =
-    (s >= "a" && s <= "z") ||
-    (s >= "A" && s <= "Z") ||
-    (s >= "0" && s <= "9")
-    where s = S.singleton c
 
   emphasis
     ∷ P.Parser String (SD.Inline a)

--- a/test/src/Test/Main.purs
+++ b/test/src/Test/Main.purs
@@ -413,7 +413,7 @@ simpleText = SD.Str <$> alphaNum
 alphaNum ∷ Gen.Gen String
 alphaNum = do
   len ← Gen.chooseInt 5 10
-  S.fromCharArray <$> Gen.vectorOf len (Gen.elements (CH.fromCharCode 97) $ L.fromFoldable (S.toCharArray "qwertyuioplkjhgfdszxcvbnm123457890"))
+  S.fromCharArray <$> Gen.vectorOf len (Gen.elements (CH.fromCharCode 97) $ L.fromFoldable (S.toCharArray "qwertyuioplkjhgfdszxcvbnm123457890ąćęóśźżĄĆĘÓŚŹŻ"))
 
 
 main ∷ ∀ e. Eff (TestEffects e) Unit


### PR DESCRIPTION
This fixes issue where using non-ascii character resulted in erroneous parsing.