### PR TITLE
Update PS to 0.13.5

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,8 +29,8 @@
     "purescript-ordered-collections": "^1.0.0",
     "purescript-parsing": "^5.0.1",
     "purescript-partial": "^2.0.0",
-    "purescript-precise": "^3.0.1",
-    "purescript-prelude": "^4.0.1",
+    "purescript-precise": "git@github.com:poorscript/purescript-precise",
+    "purescript-prelude": "^4.1.1",
     "purescript-strings": "^4.0.0",
     "purescript-unicode": "^4.0.1",
     "purescript-validation": "^4.0.0"

--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,7 @@
     "purescript-ordered-collections": "^1.0.0",
     "purescript-parsing": "^5.0.1",
     "purescript-partial": "^2.0.0",
-    "purescript-precise": "git@github.com:poorscript/purescript-precise",
+    "purescript-precise": "https://github.com/poorscript/purescript-precise.git",
     "purescript-prelude": "^4.1.1",
     "purescript-strings": "^4.0.0",
     "purescript-unicode": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,11 @@
   },
   "devDependencies": {
     "pulp": "^12.3.0",
-    "purescript": "^0.12.0",
+    "purescript": "^0.13.5",
     "purescript-psa": "^0.6.0",
     "rimraf": "^2.5.4"
+  },
+  "dependencies": {
+    "bower": "^1.8.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,8 +10,5 @@
     "purescript": "^0.13.5",
     "purescript-psa": "^0.6.0",
     "rimraf": "^2.5.4"
-  },
-  "dependencies": {
-    "bower": "^1.8.8"
   }
 }

--- a/src/Text/Markdown/SlamDown/Pretty.purs
+++ b/src/Text/Markdown/SlamDown/Pretty.purs
@@ -103,7 +103,7 @@ prettyPrintInline il =
         star = if r then "*" else" "
       in
         esc l <> star <> " = " <> prettyPrintFormElement e
-      where
+    where
 
       esc s = M.maybe s (const $ "[" <> s <> "]") $ S.indexOf (S.Pattern " ") s
 


### PR DESCRIPTION
This can solve https://github.com/slamdata/purescript-markdown/issues/86.
I added a custom `purescript-precise` source because they use old `purescript-quickcheck` which doesn't compile with PS 0.13.5. After my pull request there is merged, I can fix the sources here.